### PR TITLE
fix: Temporarily disable the esp_modem_usb_dte component (AEGHB-82)

### DIFF
--- a/components/iot_bridge/CMakeLists.txt
+++ b/components/iot_bridge/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(srcs "src/bridge_common.c")
-set(requires "esp_eth" "esp_netif" "esp_wifi" "esp_timer")
+set(requires "esp_eth" "esp_netif" "esp_wifi" "esp_timer" "esp_modem")
 set(include_dirs "include" "include/priv_inc")
 
 if (CONFIG_BRIDGE_EXTERNAL_NETIF_STATION OR CONFIG_BRIDGE_DATA_FORWARDING_NETIF_SOFTAP)
@@ -8,6 +8,10 @@ endif()
 
 if (CONFIG_BRIDGE_EXTERNAL_NETIF_MODEM)
     list(APPEND srcs "src/bridge_modem.c")
+endif()
+
+if ("${IDF_TARGET}" STREQUAL "esp32s2" OR "${IDF_TARGET}" STREQUAL "esp32s3")
+    list(APPEND requires "esp_modem_usb_dte")
 endif()
 
 if (DEFINED ENV{BRIDGE_PRIV})

--- a/components/iot_bridge/idf_component.yml
+++ b/components/iot_bridge/idf_component.yml
@@ -3,12 +3,17 @@ description: A smart bridge to make both ESP and the other MCU or smart device c
 url: https://github.com/espressif/esp-iot-bridge/tree/master/components/iot_bridge
 dependencies:
   idf: ">=4.4"
-  espressif/esp_modem:
-    version: 0.*
-  espressif/esp_modem_usb_dte:
-    version: 1.*
-    rules:
-      - if: "target in [esp32s2, esp32s3]"
+  # The "esp_modem_usb_dte" component is temporarily disabled, as idf-component-manager
+  # doesn't support uploading components with "rules" entries to the registry.
+  # Re-enable this after the bug fix in idf-component-manager is released,
+  # and increase the component version to 0.2.1.
+  #
+  # espressif/esp_modem:
+  #   version: 0.*
+  # espressif/esp_modem_usb_dte:
+  #   version: 1.*
+  #   rules:
+  #     - if: "target in [esp32s2, esp32s3]"
 examples:
   - path: ../../examples/wifi_router
   - path: ../../examples/4g_hotspot

--- a/examples/4g_hotspot/main/idf_component.yml
+++ b/examples/4g_hotspot/main/idf_component.yml
@@ -4,3 +4,14 @@ dependencies:
     version: "*"
     # Please comment the following line, if this example is installed by idf.py create-project-from-example.
     override_path: "../../../components/iot_bridge"
+  # The "esp_modem_usb_dte" component is temporarily disabled in iot_bridge yml file,
+  # as idf-component-manager doesn't support uploading components with "rules" entries to the registry.
+  # So temporarily place the "esp_modem_usb_dte" "esp_modem" component under examples.
+  #
+  espressif/esp_modem:
+    version: 0.*
+  espressif/esp_modem_usb_dte:
+    version: 1.*
+    public: true
+    rules:
+      - if: "target in [esp32s2, esp32s3]"

--- a/examples/wifi_router/main/idf_component.yml
+++ b/examples/wifi_router/main/idf_component.yml
@@ -11,3 +11,14 @@ dependencies:
   web_server:
     path: components/web_server
     git: https://github.com/espressif/esp-iot-bridge.git
+  # The "esp_modem_usb_dte" component is temporarily disabled in iot_bridge yml file,
+  # as idf-component-manager doesn't support uploading components with "rules" entries to the registry.
+  # So temporarily place the "esp_modem_usb_dte" "esp_modem" component under examples.
+  #
+  espressif/esp_modem:
+    version: 0.*
+  espressif/esp_modem_usb_dte:
+    version: 1.*
+    public: true
+    rules:
+      - if: "target in [esp32s2, esp32s3]"


### PR DESCRIPTION
# Change description
The "esp_modem_usb_dte" component is temporarily disabled, as idf-component-manager doesn't support uploading components with "rules" entries to the registry.
Re-enable this after the bug fix in idf-component-manager is released, and increase the component version to 0.2.1.