### PR TITLE
Update app_main.c

### DIFF
--- a/examples/wifi_router/main/app_main.c
+++ b/examples/wifi_router/main/app_main.c
@@ -25,6 +25,9 @@
 #include "esp_event.h"
 
 #include "esp_bridge.h"
+#if defined(CONFIG_BRIDGE_EXTERNAL_NETIF_STATION)
+#include "esp_wifi.h"
+#endif
 #if defined(CONFIG_BRIDGE_USE_WEB_SERVER)
 #include "web_server.h"
 #endif


### PR DESCRIPTION
if you not add this, you get following Error: 
```
/home/franz/git/rin/rinGate/rinGate/main/app_main.c: In function 'app_main': /home/franz/git/rin/rinGate/rinGate/main/app_main.c:129:5: error: implicit declaration of function 'esp_wifi_connect' [-Werror=implicit-function-declaration]
  129 |     esp_wifi_connect();
      |     ^~~~~~~~~~~~~~~~
cc1: some warnings being treated as errors
```

